### PR TITLE
nspawn: allow disabling /usr check

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -171,6 +171,10 @@ All tools:
   boot an OS tree without an os-release file (useful when trying to boot a
   container with empty `/etc/` and bind-mounted `/usr/`)
 
+* `$SYSTEMD_NSPAWN_CHECK_USR=0` — if set, do not fail when trying to run a
+  container with an OS tree without an `/usr` directory (useful when you are
+  going to bind-mount `/usr` later or are testing embedded images)
+
 * `$SYSTEMD_SUPPRESS_SYNC=1` — if set, all disk synchronization syscalls are
   blocked to the container payload (e.g. `sync()`, `fsync()`, `syncfs()`, …)
   and the `O_SYNC`/`O_DSYNC` flags are made unavailable to `open()` and

--- a/test/units/TEST-13-NSPAWN.nspawn.sh
+++ b/test/units/TEST-13-NSPAWN.nspawn.sh
@@ -1023,6 +1023,33 @@ testcase_check_os_release() {
     rm -fr "$root" "$base"
 }
 
+testcase_check_usr() {
+    local base common_opts root
+
+    base="$(mktemp -d /var/lib/machines/TEST-13-NSPAWN.check_usr_base.XXX)"
+    root="$(mktemp -d /var/lib/machines/TEST-13-NSPAWN.check_usr.XXX)"
+    create_dummy_container "$base"
+    cp -d "$base"/{bin,sbin,lib,lib64} "$root/"
+    common_opts=(
+        --register=no
+        --directory="$root"
+        --bind-ro="$base/usr:/usr"
+    )
+
+    # Might be needed to find libraries
+    if [ -f "$base/etc/ld.so.cache" ]; then
+        common_opts+=("--bind-ro=$base/etc/ld.so.cache:/etc/ld.so.cache")
+    fi
+
+    # /usr is bind-mounted but missing in root
+    (! systemd-nspawn "${common_opts[@]}")
+    (! SYSTEMD_NSPAWN_CHECK_USR=1 systemd-nspawn "${common_opts[@]}")
+    (! SYSTEMD_NSPAWN_CHECK_USR=foo systemd-nspawn "${common_opts[@]}")
+    SYSTEMD_NSPAWN_CHECK_USR=0 systemd-nspawn "${common_opts[@]}"
+
+    rm -fr "$root" "$base"
+}
+
 testcase_ip_masquerade() {
     local root
 


### PR DESCRIPTION
Introduce a new env variable $SYSTEMD_NSPAWN_CHECK_USR, that can be used to disable the /usr check for non-bootable OS trees. See c9bcca92085a87e3a14ec79b8c8e81d9eefe3c84 for bootable OS tree counterpart.