### PR TITLE
nspawn: allow disabling /usr check

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -171,6 +171,10 @@ All tools:
   boot an OS tree without an os-release file (useful when trying to boot a
   container with empty `/etc/` and bind-mounted `/usr/`)
 
+* `$SYSTEMD_NSPAWN_CHECK_USR=0` — if set, do not fail when trying to run a
+  container with an OS tree without an `/usr` directory (useful when you are
+  going to bind-mount `/usr` later or are testing embedded images)
+
 * `$SYSTEMD_SUPPRESS_SYNC=1` — if set, all disk synchronization syscalls are
   blocked to the container payload (e.g. `sync()`, `fsync()`, `syncfs()`, …)
   and the `O_SYNC`/`O_DSYNC` flags are made unavailable to `open()` and


### PR DESCRIPTION
systemd-nspawn has a bunch of validations to prevent users from running (and then having to debug) containers that don't "smell" like correct OS images. However, sometimes there are some unusual usecases, for which environment variables have to offer a way to say "I know what I'm doing".

Here I am adding a new env variable `$SYSTEMD_NSPAWN_CHECK_USR`, that can be used to disable the `/usr` existence check for non-bootable OS trees. See https://github.com/systemd/systemd/pull/29844 for an existing counterpart for bootable OS trees.

My usecase is that I'm running systemd-nspawn in a clean directory, and then bind-mount all directories on top of it, like so:

```
sudo env SYSTEMD_NSPAWN_CHECK_USR=0 systemd-nspawn \
  --volatile=overlay \
  --directory /usr/share/empty \
  --bind-ro /bin:/bin \
  --bind-ro /lib64:/lib64 \
  --bind-ro /usr:/usr \
  ...
```

The OS tree validation happens before bind mounts are processed, so currently systemd-nspawn will fail here with `Directory /usr/share/empty doesn't look like it has an OS tree (/usr/ directory is missing). Refusing.`.