### PR TITLE
mount-util: preserve colons as-is (for overlayfs)

### DIFF
--- a/src/shared/mount-util.c
+++ b/src/shared/mount-util.c
@@ -812,7 +812,7 @@ int mount_option_mangle(
                 _cleanup_free_ char *word = NULL;
                 const struct libmnt_optmap *ent;
 
-                r = extract_first_word(&p, &word, ",", EXTRACT_KEEP_QUOTE);
+                r = extract_first_word(&p, &word, ",", EXTRACT_KEEP_QUOTE | EXTRACT_RETAIN_ESCAPE);
                 if (r < 0)
                         return r;
                 if (r == 0)

--- a/src/test/test-mount-util.c
+++ b/src/test/test-mount-util.c
@@ -82,6 +82,11 @@ TEST(mount_option_mangle) {
         assert_se(f == 0);
         ASSERT_STREQ(opts, "mode=01777,size=10%,nr_inodes=400k,uid=496107520,gid=496107520,context=\"system_u:object_r:svirt_sandbox_file_t:s0:c0,c1\"");
         opts = mfree(opts);
+
+        assert_se(mount_option_mangle("lower=/path/one/with/some\\:colons:/path/two", 0, &f, &opts) == 0);
+        assert_se(f == 0);
+        ASSERT_STREQ(opts, "lower=/path/one/with/some\\:colons:/path/two");
+        opts = mfree(opts);
 }
 
 static void test_mount_flags_to_string_one(unsigned long flags, const char *expected) {


### PR DESCRIPTION
For overlayfs options, there is a significant difference between escaped and unescaped colon. `mount_option_mangle` discards backslash escapes, therefore making it unable to e.g. start `systemd-nspawn` with `--volatile=overlay` if the `--directory` contains a colon.

## Testing

Given these commands:

```bash
mkdir build/test:root
mkdir build/test:root/usr # see https://github.com/systemd/systemd/pull/34808
sudo build/systemd-nspawn \
  --register=false \
  --volatile=overlay --directory build/test:root \
  --bind-ro /bin:/bin --bind-ro /lib64:/lib64 --bind-ro /usr:/usr \
  --console interactive \
  bash
```

## Before

Fails with `Failed to mount overlay (type overlay) on /home/pawo2500/systemd/build/test:root (0 "lowerdir=/home/pawo2500/systemd/build/test:root,upperdir=/tmp/nspawn-volatile-ASsckb/upper,workdir=/tmp/nspawn-volatile-ASsckb/work"): No such file or directory`, because the colon in `test:root` causes kernel to treat this as two paths instead of one.

<details>
  <summary>Full log</summary>

```text
Setting RLIMIT_CPU to infinity.
Setting RLIMIT_FSIZE to infinity.
Setting RLIMIT_DATA to infinity.
Setting RLIMIT_STACK to 8388608:infinity.
Setting RLIMIT_CORE to 0:infinity.
Setting RLIMIT_RSS to infinity.
Setting RLIMIT_NPROC to 63595.
Setting RLIMIT_NOFILE to 1024:524288.
Setting RLIMIT_MEMLOCK to 8388608.
Setting RLIMIT_AS to infinity.
Setting RLIMIT_LOCKS to infinity.
Setting RLIMIT_SIGPENDING to 63595.
Setting RLIMIT_MSGQUEUE to 819200.
Setting RLIMIT_NICE to 0.
Setting RLIMIT_RTPRIO to 0.
Setting RLIMIT_RTTIME to infinity.
Found cgroup2 on /sys/fs/cgroup/, full unified hierarchy
Spawning container testroot on /home/pawo2500/systemd/build/test:root.
Press Ctrl-] three times within 1s to kill container.
Outer child is initializing.
Changing mount propagation / (MS_REC|MS_SLAVE "")
Bind-mounting /home/pawo2500/systemd/build/test:root on /home/pawo2500/systemd/build/test:root (MS_BIND|MS_REC "")...
Changing mount propagation /home/pawo2500/systemd/build/test:root (MS_REC|MS_PRIVATE "")
Mounting tmpfs (tmpfs) on /tmp/nspawn-volatile-ASsckb (MS_STRICTATIME "mode=0755,size=25%,nr_inodes=1m")...
Mounting overlay (overlay) on /home/pawo2500/systemd/build/test:root (0 "lowerdir=/home/pawo2500/systemd/build/test:root,upperdir=/tmp/nspawn-volatile-ASsckb/upper,workdir=/tmp/nspawn-volatile-ASsckb/work")...
Failed to mount overlay (type overlay) on /home/pawo2500/systemd/build/test:root (0 "lowerdir=/home/pawo2500/systemd/build/test:root,upperdir=/tmp/nspawn-volatile-ASsckb/upper,workdir=/tmp/nspawn-volatile-ASsckb/work"): No such file or directory
Umounting /tmp/nspawn-volatile-ASsckb...
Short read while reading cgroup mode (0 bytes). The child is most likely dead.
```

</details>

## After

Just works.

<details>
  <summary>Full log</summary>

```text
Setting RLIMIT_CPU to infinity.
Setting RLIMIT_FSIZE to infinity.
Setting RLIMIT_DATA to infinity.
Setting RLIMIT_STACK to 8388608:infinity.
Setting RLIMIT_CORE to 0:infinity.
Setting RLIMIT_RSS to infinity.
Setting RLIMIT_NPROC to 63595.
Setting RLIMIT_NOFILE to 1024:524288.
Setting RLIMIT_MEMLOCK to 8388608.
Setting RLIMIT_AS to infinity.
Setting RLIMIT_LOCKS to infinity.
Setting RLIMIT_SIGPENDING to 63595.
Setting RLIMIT_MSGQUEUE to 819200.
Setting RLIMIT_NICE to 0.
Setting RLIMIT_RTPRIO to 0.
Setting RLIMIT_RTTIME to infinity.
Resolved versioned directory pattern '/home/pawo2500/systemd/build/test:root' to file '/home/pawo2500/systemd/build/test:root' as version 'n/a'.
Found cgroup2 on /sys/fs/cgroup/, full unified hierarchy
░ Spawning container testroot on /home/pawo2500/systemd/build/test:root.
░ Press Ctrl-] three times within 1s to kill container.
Mounting tmpfs (tmpfs) on /run/systemd/nspawn/unix-export/testroot (MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_NOSYMFOLLOW "size=4M,nr_inodes=64,mode=0755")...
Changing mount flags /run/systemd/nspawn/unix-export/testroot (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_NOSYMFOLLOW|MS_BIND "")...
Outer child is initializing.
Changing mount propagation / (MS_REC|MS_SLAVE "")
Bind-mounting /home/pawo2500/systemd/build/test:root on /home/pawo2500/systemd/build/test:root (MS_BIND|MS_REC "")...
Changing mount propagation /home/pawo2500/systemd/build/test:root (MS_REC|MS_PRIVATE "")
Mounting tmpfs (tmpfs) on /tmp/nspawn-volatile-IL1VFn (MS_STRICTATIME "mode=0755,size=25%,nr_inodes=1m")...
Mounting overlay (overlay) on /home/pawo2500/systemd/build/test:root (0 "lowerdir=/home/pawo2500/systemd/build/test\:root,upperdir=/tmp/nspawn-volatile-IL1VFn/upper,workdir=/tmp/nspawn-volatile-IL1VFn/work")...
Umounting /tmp/nspawn-volatile-IL1VFn...
Using unified hierarchy for container.
Mounting tmpfs (tmpfs) on /home/pawo2500/systemd/build/test:root/tmp (MS_NOSUID|MS_NODEV|MS_STRICTATIME "mode=01777,size=10%,nr_inodes=400k,uid=0,gid=0")...
Mounting sysfs (sysfs) on /home/pawo2500/systemd/build/test:root/sys (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC "")...
Mounting tmpfs (tmpfs) on /home/pawo2500/systemd/build/test:root/dev (MS_NOSUID|MS_STRICTATIME "mode=0755,size=4m,nr_inodes=64k,uid=0,gid=0")...
Mounting tmpfs (tmpfs) on /home/pawo2500/systemd/build/test:root/dev/shm (MS_NOSUID|MS_NODEV|MS_STRICTATIME "mode=01777,size=10%,nr_inodes=400k,uid=0,gid=0")...
Mounting tmpfs (tmpfs) on /home/pawo2500/systemd/build/test:root/run (MS_NOSUID|MS_NODEV|MS_STRICTATIME "mode=0755,size=20%,nr_inodes=800k,uid=0,gid=0")...
Bind-mounting /home/pawo2500/systemd/build/test:root/run/host on /home/pawo2500/systemd/build/test:root/run/host (MS_BIND "")...
Bind-mounting /etc/os-release on /home/pawo2500/systemd/build/test:root/run/host/os-release (MS_BIND "")...
Changing mount flags /home/pawo2500/systemd/build/test:root/run/host/os-release (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Changing mount propagation /home/pawo2500/systemd/build/test:root/run/host/os-release (MS_PRIVATE "")
Bind-mounting /sys/fs/selinux on /home/pawo2500/systemd/build/test:root/sys/fs/selinux (MS_BIND "")...
Changing mount flags /home/pawo2500/systemd/build/test:root/sys/fs/selinux (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Changing mount propagation /home/pawo2500/systemd/build/test:root/sys/fs/selinux (MS_PRIVATE "")
Creating mount fd for nspawn-fuse (fuse.nspawn) (0 "fd=9,rootmode=40000,user_id=0,group_id=0")...
Bind-mounting /run/systemd/nspawn/unix-export/testroot on /home/pawo2500/systemd/build/test:root/run/host/unix-export (MS_BIND "")...
Changing mount flags /home/pawo2500/systemd/build/test:root/run/host/unix-export (MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_NOSYMFOLLOW|MS_BIND "")...
Mounting devpts (devpts) on /home/pawo2500/systemd/build/test:root/dev/pts (MS_NOSUID|MS_NOEXEC "newinstance,ptmxmode=0666,mode=620,gid=5")...
Bind-mounting /run/systemd/nspawn/propagate/testroot on /home/pawo2500/systemd/build/test:root/run/host/incoming (MS_BIND "")...
Changing mount flags /home/pawo2500/systemd/build/test:root/run/host/incoming (MS_RDONLY|MS_REMOUNT|MS_BIND "")...
Bind-mounting /bin on /home/pawo2500/systemd/build/test:root/bin (MS_BIND|MS_REC "")...
Bind-mounting /lib64 on /home/pawo2500/systemd/build/test:root/lib64 (MS_BIND|MS_REC "")...
Bind-mounting /usr on /home/pawo2500/systemd/build/test:root/usr (MS_BIND|MS_REC "")...
Bus n/a: changing state UNSET → OPENING
sd-bus: starting bus by connecting to /run/dbus/system_bus_socket...
Bus n/a: changing state OPENING → AUTHENTICATING
Bus n/a: changing state AUTHENTICATING → HELLO
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=Hello cookie=1 reply_cookie=0 signature=n/a error-name=n/a error-message=n/a
Got message type=method_return sender=org.freedesktop.DBus destination=:1.197 path=n/a interface=n/a member=n/a  cookie=4294967295 reply_cookie=1 signature=s error-name=n/a error-message=n/a
Bus n/a: changing state HELLO → RUNNING
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/dbus interface=org.freedesktop.DBus member=NameHasOwner cookie=2 reply_cookie=0 signature=s error-name=n/a error-message=n/a
Got message type=method_return sender=org.freedesktop.DBus destination=:1.197 path=n/a interface=n/a member=n/a  cookie=4294967295 reply_cookie=2 signature=b error-name=n/a error-message=n/a
Sent message type=method_call sender=n/a destination=org.freedesktop.resolve1 path=/org/freedesktop/resolve1 interface=org.freedesktop.DBus.Properties member=Get cookie=3 reply_cookie=0 signature=ss error-name=n/a error-message=n/a
Got message type=method_return sender=:1.1 destination=:1.197 path=n/a interface=n/a member=n/a  cookie=28 reply_cookie=3 signature=v error-name=n/a error-message=n/a
Bus n/a: changing state RUNNING → CLOSED
Changing mount propagation /run/host/incoming (MS_SLAVE "")
Inner child is initializing.
Mounting proc (proc) on /proc (MS_NOSUID|MS_NODEV|MS_NOEXEC "")...
Bind-mounting /proc/sys on /proc/sys (MS_BIND "")...
Changing mount flags /proc/sys (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bind-mounting /run/systemd/inaccessible/reg on /proc/kallsyms (MS_BIND "")...
Failed to mount /run/systemd/inaccessible/reg (type n/a) on /proc/kallsyms (MS_BIND ""): No such file or directory
Changing mount flags /proc/kallsyms (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/kallsyms (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): Invalid argument
Bind-mounting /run/systemd/inaccessible/reg on /proc/kcore (MS_BIND "")...
Failed to mount /run/systemd/inaccessible/reg (type n/a) on /proc/kcore (MS_BIND ""): No such file or directory
Changing mount flags /proc/kcore (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/kcore (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): Invalid argument
Bind-mounting /run/systemd/inaccessible/reg on /proc/keys (MS_BIND "")...
Failed to mount /run/systemd/inaccessible/reg (type n/a) on /proc/keys (MS_BIND ""): No such file or directory
Changing mount flags /proc/keys (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/keys (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): Invalid argument
Bind-mounting /run/systemd/inaccessible/reg on /proc/sysrq-trigger (MS_BIND "")...
(sd-namespace) succeeded.
Init process invoked as PID 278268
Failed to mount /run/systemd/inaccessible/reg (type n/a) on /proc/sysrq-trigger (MS_BIND ""): No such file or directory
Bus n/a: changing state UNSET → OPENING
sd-bus: starting bus by connecting to /run/dbus/system_bus_socket...
Changing mount flags /proc/sysrq-trigger (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/sysrq-trigger (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): Invalid argument
Bus n/a: changing state OPENING → AUTHENTICATING
Bind-mounting /run/systemd/inaccessible/reg on /proc/timer_list (MS_BIND "")...
Failed to mount /run/systemd/inaccessible/reg (type n/a) on /proc/timer_list (MS_BIND ""): No such file or directory
Changing mount flags /proc/timer_list (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/timer_list (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): Invalid argument
Bind-mounting /proc/acpi on /proc/acpi (MS_BIND "")...
Changing mount flags /proc/acpi (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bus n/a: changing state AUTHENTICATING → HELLO
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=Hello cookie=1 reply_cookie=0 signature=n/a error-name=n/a error-message=n/a
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=AddMatch cookie=2 reply_cookie=0 signature=s error-name=n/a error-message=n/a
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=AddMatch cookie=3 reply_cookie=0 signature=s error-name=n/a error-message=n/a
Bind-mounting /proc/apm on /proc/apm (MS_BIND "")...
Failed to mount /proc/apm (type n/a) on /proc/apm (MS_BIND ""): No such file or directory
Changing mount flags /proc/apm (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Failed to mount n/a (type n/a) on /proc/apm (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND ""): No such file or directory
Bind-mounting /proc/asound on /proc/asound (MS_BIND "")...
Changing mount flags /proc/asound (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Got message type=method_return sender=org.freedesktop.DBus destination=:1.198 path=n/a interface=n/a member=n/a  cookie=4294967295 reply_cookie=1 signature=s error-name=n/a error-message=n/a
Bus n/a: changing state HELLO → RUNNING
Sent message type=method_call sender=n/a destination=org.freedesktop.systemd1 path=/org/freedesktop/systemd1 interface=org.freedesktop.systemd1.Manager member=StartTransientUnit cookie=4 reply_cookie=0 signature=ssa(sv)a(sa(sv)) error-name=n/a error-message=n/a
Bind-mounting /proc/bus on /proc/bus (MS_BIND "")...
Changing mount flags /proc/bus (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bind-mounting /proc/fs on /proc/fs (MS_BIND "")...
Changing mount flags /proc/fs (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bind-mounting /proc/irq on /proc/irq (MS_BIND "")...
Changing mount flags /proc/irq (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bind-mounting /proc/scsi on /proc/scsi (MS_BIND "")...
Changing mount flags /proc/scsi (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Mounting mqueue (mqueue) on /dev/mqueue (MS_NOSUID|MS_NODEV|MS_NOEXEC "")...
Changing mount flags /run/host (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Got message type=method_return sender=:1.2 destination=:1.198 path=n/a interface=n/a member=n/a  cookie=7106 reply_cookie=4 signature=o error-name=n/a error-message=n/a
Got message type=signal sender=org.freedesktop.DBus destination=:1.198 path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=NameAcquired  cookie=4294967295 reply_cookie=0 signature=s error-name=n/a error-message=n/a
Got message type=method_return sender=org.freedesktop.DBus destination=:1.198 path=n/a interface=n/a member=n/a  cookie=4294967295 reply_cookie=2 signature= error-name=n/a error-message=n/a
Match type='signal',sender='org.freedesktop.systemd1',interface='org.freedesktop.systemd1.Scope',member='RequestStop' successfully installed.
Got message type=method_return sender=org.freedesktop.DBus destination=:1.198 path=n/a interface=n/a member=n/a  cookie=4294967295 reply_cookie=3 signature= error-name=n/a error-message=n/a
Match type='signal',sender='org.freedesktop.systemd1',path='/org/freedesktop/systemd1',interface='org.freedesktop.systemd1.Manager',member='JobRemoved' successfully installed.
Got message type=signal sender=:1.2 destination=n/a path=/org/freedesktop/systemd1 interface=org.freedesktop.systemd1.Manager member=JobRemoved  cookie=7115 reply_cookie=0 signature=uoss error-name=n/a error-message=n/a
Got result done/Success for job testroot.scope.
Sent message type=method_call sender=n/a destination=org.freedesktop.DBus path=/org/freedesktop/DBus interface=org.freedesktop.DBus member=RemoveMatch cookie=5 reply_cookie=0 signature=s error-name=n/a error-message=n/a
Failed to chown "/sys/fs/cgroup/machine.slice/testroot.scope/payload/cgroup.clone_children", ignoring: No such file or directory
Failed to chown "/sys/fs/cgroup/machine.slice/testroot.scope/payload/memory.oom.group", ignoring: No such file or directory
Failed to chown "/sys/fs/cgroup/machine.slice/testroot.scope/payload/memory.reclaim", ignoring: No such file or directory
Failed to chown "/sys/fs/cgroup/machine.slice/testroot.scope/payload/notify_on_release", ignoring: No such file or directory
Failed to chown "/sys/fs/cgroup/machine.slice/testroot.scope/payload/tasks", ignoring: No such file or directory
Mounting cgroup (cgroup2) on /sys/fs/cgroup (MS_NOSUID|MS_NODEV|MS_NOEXEC "")...
Bind-mounting /run/.#proc-sys-kernel-random-boot-idc080561573601621 on /proc/sys/kernel/random/boot_id (MS_BIND "")...
Changing mount flags /proc/sys/kernel/random/boot_id (MS_RDONLY|MS_NOSUID|MS_NODEV|MS_NOEXEC|MS_REMOUNT|MS_BIND "")...
Bind-mounting /run/.#proc-kmsgac5c65aa6fbca1a9 on /proc/kmsg (MS_BIND "")...
Applying allow list on architecture: x86
Failed to add rule for system call security() / 185, ignoring: Numerical argument out of domain
Failed to add rule for system call tuxcall() / 184, ignoring: Numerical argument out of domain
System call arc_gettls is not known, ignoring.
System call arc_settls is not known, ignoring.
System call arc_usr_cmpxchg is not known, ignoring.
Failed to add rule for system call arm_fadvise64_64() / -10083, ignoring: Numerical argument out of domain
System call atomic_barrier is not known, ignoring.
System call atomic_cmpxchg_32 is not known, ignoring.
Failed to add rule for system call cachectl() / -10103, ignoring: Numerical argument out of domain
System call dipc is not known, ignoring.
System call exec_with_loader is not known, ignoring.
System call execv is not known, ignoring.
System call getdomainname is not known, ignoring.
System call getdtablesize is not known, ignoring.
System call gethostname is not known, ignoring.
System call getpagesize is not known, ignoring.
System call getxgid is not known, ignoring.
System call getxpid is not known, ignoring.
System call getxuid is not known, ignoring.
System call kern_features is not known, ignoring.
Failed to add rule for system call kexec_file_load() / 320, ignoring: Numerical argument out of domain
System call listmount is not known, ignoring.
System call llseek is not known, ignoring.
System call lsm_get_self_attr is not known, ignoring.
System call lsm_list_modules is not known, ignoring.
System call lsm_set_self_attr is not known, ignoring.
System call memory_ordering is not known, ignoring.
System call mseal is not known, ignoring.
Failed to add rule for system call multiplexer() / -10186, ignoring: Numerical argument out of domain
System call old_adjtimex is not known, ignoring.
System call oldumount is not known, ignoring.
System call or1k_atomic is not known, ignoring.
System call osf_fstat is not known, ignoring.
System call osf_fstatfs is not known, ignoring.
System call osf_fstatfs64 is not known, ignoring.
System call osf_getdirentries is not known, ignoring.
System call osf_getdomainname is not known, ignoring.
System call osf_getitimer is not known, ignoring.
System call osf_getrusage is not known, ignoring.
System call osf_getsysinfo is not known, ignoring.
System call osf_gettimeofday is not known, ignoring.
System call osf_lstat is not known, ignoring.
System call osf_mount is not known, ignoring.
System call osf_proplist_syscall is not known, ignoring.
System call osf_select is not known, ignoring.
System call osf_set_program_attributes is not known, ignoring.
System call osf_setitimer is not known, ignoring.
System call osf_setsysinfo is not known, ignoring.
System call osf_settimeofday is not known, ignoring.
System call osf_shmat is not known, ignoring.
System call osf_sigprocmask is not known, ignoring.
System call osf_sigstack is not known, ignoring.
System call osf_stat is not known, ignoring.
System call osf_statfs is not known, ignoring.
System call osf_statfs64 is not known, ignoring.
System call osf_swapon is not known, ignoring.
System call osf_syscall is not known, ignoring.
System call osf_sysinfo is not known, ignoring.
System call osf_usleep_thread is not known, ignoring.
System call osf_utimes is not known, ignoring.
System call osf_utsname is not known, ignoring.
System call osf_wait4 is not known, ignoring.
Failed to add rule for system call pciconfig_iobase() / -10086, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_read() / -10087, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_write() / -10088, ignoring: Numerical argument out of domain
System call perfctr is not known, ignoring.
System call riscv_hwprobe is not known, ignoring.
Failed to add rule for system call rtas() / -10187, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_guarded_storage() / -10205, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_read() / -10197, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_write() / -10198, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_runtime_instr() / -10196, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_sthyi() / -10206, ignoring: Numerical argument out of domain
System call sched_get_affinity is not known, ignoring.
System call sched_set_affinity is not known, ignoring.
System call sethae is not known, ignoring.
System call setpgrp is not known, ignoring.
Failed to add rule for system call spu_create() / -10188, ignoring: Numerical argument out of domain
Failed to add rule for system call spu_run() / -10189, ignoring: Numerical argument out of domain
System call statmount is not known, ignoring.
Failed to add rule for system call subpage_prot() / -10207, ignoring: Numerical argument out of domain
Failed to add rule for system call switch_endian() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call sys_debug_setcontext() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call syscall() / -10090, ignoring: Numerical argument out of domain
Failed to add rule for system call sysmips() / -10106, ignoring: Numerical argument out of domain
Failed to add rule for system call timerfd() / -10107, ignoring: Numerical argument out of domain
System call uretprobe is not known, ignoring.
System call utrap_install is not known, ignoring.
Applying allow list on architecture: x32
Failed to add rule for system call _sysctl() / 156, ignoring: Numerical argument out of domain
Failed to add rule for system call bdflush() / -10002, ignoring: Numerical argument out of domain
Failed to add rule for system call break() / -10003, ignoring: Numerical argument out of domain
Failed to add rule for system call create_module() / 174, ignoring: Numerical argument out of domain
Failed to add rule for system call ftime() / -10013, ignoring: Numerical argument out of domain
Failed to add rule for system call get_kernel_syms() / 177, ignoring: Numerical argument out of domain
Failed to add rule for system call gtty() / -10022, ignoring: Numerical argument out of domain
Failed to add rule for system call idle() / -10023, ignoring: Numerical argument out of domain
Failed to add rule for system call lock() / -10027, ignoring: Numerical argument out of domain
Failed to add rule for system call mpx() / -10030, ignoring: Numerical argument out of domain
Failed to add rule for system call prof() / -10039, ignoring: Numerical argument out of domain
Failed to add rule for system call profil() / -10040, ignoring: Numerical argument out of domain
Failed to add rule for system call query_module() / 178, ignoring: Numerical argument out of domain
Failed to add rule for system call sgetmask() / -10053, ignoring: Numerical argument out of domain
Failed to add rule for system call ssetmask() / -10061, ignoring: Numerical argument out of domain
Failed to add rule for system call stime() / -10064, ignoring: Numerical argument out of domain
Failed to add rule for system call stty() / -10065, ignoring: Numerical argument out of domain
Failed to add rule for system call ulimit() / -10069, ignoring: Numerical argument out of domain
Failed to add rule for system call uselib() / 134, ignoring: Numerical argument out of domain
Failed to add rule for system call vserver() / 236, ignoring: Numerical argument out of domain
System call arc_gettls is not known, ignoring.
System call arc_settls is not known, ignoring.
System call arc_usr_cmpxchg is not known, ignoring.
Failed to add rule for system call arm_fadvise64_64() / -10083, ignoring: Numerical argument out of domain
System call atomic_barrier is not known, ignoring.
System call atomic_cmpxchg_32 is not known, ignoring.
Failed to add rule for system call cachectl() / -10103, ignoring: Numerical argument out of domain
Failed to add rule for system call clock_adjtime64() / -10212, ignoring: Numerical argument out of domain
Failed to add rule for system call clock_settime64() / -10216, ignoring: Numerical argument out of domain
System call dipc is not known, ignoring.
System call exec_with_loader is not known, ignoring.
System call execv is not known, ignoring.
System call getdomainname is not known, ignoring.
System call getdtablesize is not known, ignoring.
System call gethostname is not known, ignoring.
System call getpagesize is not known, ignoring.
System call getxgid is not known, ignoring.
System call getxpid is not known, ignoring.
System call getxuid is not known, ignoring.
System call kern_features is not known, ignoring.
System call listmount is not known, ignoring.
System call llseek is not known, ignoring.
System call lsm_get_self_attr is not known, ignoring.
System call lsm_list_modules is not known, ignoring.
System call lsm_set_self_attr is not known, ignoring.
Failed to add rule for system call map_shadow_stack() / 453, ignoring: Numerical argument out of domain
System call memory_ordering is not known, ignoring.
System call mseal is not known, ignoring.
Failed to add rule for system call multiplexer() / -10186, ignoring: Numerical argument out of domain
System call old_adjtimex is not known, ignoring.
System call oldumount is not known, ignoring.
System call or1k_atomic is not known, ignoring.
System call osf_fstat is not known, ignoring.
System call osf_fstatfs is not known, ignoring.
System call osf_fstatfs64 is not known, ignoring.
System call osf_getdirentries is not known, ignoring.
System call osf_getdomainname is not known, ignoring.
System call osf_getitimer is not known, ignoring.
System call osf_getrusage is not known, ignoring.
System call osf_getsysinfo is not known, ignoring.
System call osf_gettimeofday is not known, ignoring.
System call osf_lstat is not known, ignoring.
System call osf_mount is not known, ignoring.
System call osf_proplist_syscall is not known, ignoring.
System call osf_select is not known, ignoring.
System call osf_set_program_attributes is not known, ignoring.
System call osf_setitimer is not known, ignoring.
System call osf_setsysinfo is not known, ignoring.
System call osf_settimeofday is not known, ignoring.
System call osf_shmat is not known, ignoring.
System call osf_sigprocmask is not known, ignoring.
System call osf_sigstack is not known, ignoring.
System call osf_stat is not known, ignoring.
System call osf_statfs is not known, ignoring.
System call osf_statfs64 is not known, ignoring.
System call osf_swapon is not known, ignoring.
System call osf_syscall is not known, ignoring.
System call osf_sysinfo is not known, ignoring.
System call osf_usleep_thread is not known, ignoring.
System call osf_utimes is not known, ignoring.
System call osf_utsname is not known, ignoring.
System call osf_wait4 is not known, ignoring.
Failed to add rule for system call pciconfig_iobase() / -10086, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_read() / -10087, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_write() / -10088, ignoring: Numerical argument out of domain
System call perfctr is not known, ignoring.
System call riscv_hwprobe is not known, ignoring.
Failed to add rule for system call rtas() / -10187, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_guarded_storage() / -10205, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_read() / -10197, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_write() / -10198, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_runtime_instr() / -10196, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_sthyi() / -10206, ignoring: Numerical argument out of domain
System call sched_get_affinity is not known, ignoring.
System call sched_set_affinity is not known, ignoring.
System call sethae is not known, ignoring.
System call setpgrp is not known, ignoring.
Failed to add rule for system call sgetmask() / -10053, ignoring: Numerical argument out of domain
Failed to add rule for system call spu_create() / -10188, ignoring: Numerical argument out of domain
Failed to add rule for system call spu_run() / -10189, ignoring: Numerical argument out of domain
Failed to add rule for system call ssetmask() / -10061, ignoring: Numerical argument out of domain
System call statmount is not known, ignoring.
Failed to add rule for system call stime() / -10064, ignoring: Numerical argument out of domain
Failed to add rule for system call subpage_prot() / -10207, ignoring: Numerical argument out of domain
Failed to add rule for system call switch_endian() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call sys_debug_setcontext() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call syscall() / -10090, ignoring: Numerical argument out of domain
Failed to add rule for system call sysmips() / -10106, ignoring: Numerical argument out of domain
Failed to add rule for system call timerfd() / -10107, ignoring: Numerical argument out of domain
System call uretprobe is not known, ignoring.
System call utrap_install is not known, ignoring.
Failed to add rule for system call vm86() / -10071, ignoring: Numerical argument out of domain
Failed to add rule for system call vm86old() / -10072, ignoring: Numerical argument out of domain
Applying allow list on architecture: x86-64
Failed to add rule for system call bdflush() / -10002, ignoring: Numerical argument out of domain
Failed to add rule for system call break() / -10003, ignoring: Numerical argument out of domain
Failed to add rule for system call ftime() / -10013, ignoring: Numerical argument out of domain
Failed to add rule for system call gtty() / -10022, ignoring: Numerical argument out of domain
Failed to add rule for system call idle() / -10023, ignoring: Numerical argument out of domain
Failed to add rule for system call lock() / -10027, ignoring: Numerical argument out of domain
Failed to add rule for system call mpx() / -10030, ignoring: Numerical argument out of domain
Failed to add rule for system call prof() / -10039, ignoring: Numerical argument out of domain
Failed to add rule for system call profil() / -10040, ignoring: Numerical argument out of domain
Failed to add rule for system call sgetmask() / -10053, ignoring: Numerical argument out of domain
Failed to add rule for system call ssetmask() / -10061, ignoring: Numerical argument out of domain
Failed to add rule for system call stime() / -10064, ignoring: Numerical argument out of domain
Failed to add rule for system call stty() / -10065, ignoring: Numerical argument out of domain
Failed to add rule for system call ulimit() / -10069, ignoring: Numerical argument out of domain
System call arc_gettls is not known, ignoring.
System call arc_settls is not known, ignoring.
System call arc_usr_cmpxchg is not known, ignoring.
Failed to add rule for system call arm_fadvise64_64() / -10083, ignoring: Numerical argument out of domain
System call atomic_barrier is not known, ignoring.
System call atomic_cmpxchg_32 is not known, ignoring.
Failed to add rule for system call cachectl() / -10103, ignoring: Numerical argument out of domain
Failed to add rule for system call clock_adjtime64() / -10212, ignoring: Numerical argument out of domain
Failed to add rule for system call clock_settime64() / -10216, ignoring: Numerical argument out of domain
System call dipc is not known, ignoring.
System call exec_with_loader is not known, ignoring.
System call execv is not known, ignoring.
System call getdomainname is not known, ignoring.
System call getdtablesize is not known, ignoring.
System call gethostname is not known, ignoring.
System call getpagesize is not known, ignoring.
System call getxgid is not known, ignoring.
System call getxpid is not known, ignoring.
System call getxuid is not known, ignoring.
System call kern_features is not known, ignoring.
System call listmount is not known, ignoring.
System call llseek is not known, ignoring.
System call lsm_get_self_attr is not known, ignoring.
System call lsm_list_modules is not known, ignoring.
System call lsm_set_self_attr is not known, ignoring.
System call memory_ordering is not known, ignoring.
System call mseal is not known, ignoring.
Failed to add rule for system call multiplexer() / -10186, ignoring: Numerical argument out of domain
System call old_adjtimex is not known, ignoring.
System call oldumount is not known, ignoring.
System call or1k_atomic is not known, ignoring.
System call osf_fstat is not known, ignoring.
System call osf_fstatfs is not known, ignoring.
System call osf_fstatfs64 is not known, ignoring.
System call osf_getdirentries is not known, ignoring.
System call osf_getdomainname is not known, ignoring.
System call osf_getitimer is not known, ignoring.
System call osf_getrusage is not known, ignoring.
System call osf_getsysinfo is not known, ignoring.
System call osf_gettimeofday is not known, ignoring.
System call osf_lstat is not known, ignoring.
System call osf_mount is not known, ignoring.
System call osf_proplist_syscall is not known, ignoring.
System call osf_select is not known, ignoring.
System call osf_set_program_attributes is not known, ignoring.
System call osf_setitimer is not known, ignoring.
System call osf_setsysinfo is not known, ignoring.
System call osf_settimeofday is not known, ignoring.
System call osf_shmat is not known, ignoring.
System call osf_sigprocmask is not known, ignoring.
System call osf_sigstack is not known, ignoring.
System call osf_stat is not known, ignoring.
System call osf_statfs is not known, ignoring.
System call osf_statfs64 is not known, ignoring.
System call osf_swapon is not known, ignoring.
System call osf_syscall is not known, ignoring.
System call osf_sysinfo is not known, ignoring.
System call osf_usleep_thread is not known, ignoring.
System call osf_utimes is not known, ignoring.
System call osf_utsname is not known, ignoring.
System call osf_wait4 is not known, ignoring.
Failed to add rule for system call pciconfig_iobase() / -10086, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_read() / -10087, ignoring: Numerical argument out of domain
Failed to add rule for system call pciconfig_write() / -10088, ignoring: Numerical argument out of domain
System call perfctr is not known, ignoring.
System call riscv_hwprobe is not known, ignoring.
Failed to add rule for system call rtas() / -10187, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_guarded_storage() / -10205, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_read() / -10197, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_pci_mmio_write() / -10198, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_runtime_instr() / -10196, ignoring: Numerical argument out of domain
Failed to add rule for system call s390_sthyi() / -10206, ignoring: Numerical argument out of domain
System call sched_get_affinity is not known, ignoring.
System call sched_set_affinity is not known, ignoring.
System call sethae is not known, ignoring.
System call setpgrp is not known, ignoring.
Failed to add rule for system call sgetmask() / -10053, ignoring: Numerical argument out of domain
Failed to add rule for system call spu_create() / -10188, ignoring: Numerical argument out of domain
Failed to add rule for system call spu_run() / -10189, ignoring: Numerical argument out of domain
Failed to add rule for system call ssetmask() / -10061, ignoring: Numerical argument out of domain
System call statmount is not known, ignoring.
Failed to add rule for system call stime() / -10064, ignoring: Numerical argument out of domain
Failed to add rule for system call subpage_prot() / -10207, ignoring: Numerical argument out of domain
Failed to add rule for system call switch_endian() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call sys_debug_setcontext() / -10191, ignoring: Numerical argument out of domain
Failed to add rule for system call syscall() / -10090, ignoring: Numerical argument out of domain
Failed to add rule for system call sysmips() / -10106, ignoring: Numerical argument out of domain
Failed to add rule for system call timerfd() / -10107, ignoring: Numerical argument out of domain
System call uretprobe is not known, ignoring.
System call utrap_install is not known, ignoring.
Failed to add rule for system call vm86() / -10071, ignoring: Numerical argument out of domain
Failed to add rule for system call vm86old() / -10072, ignoring: Numerical argument out of domain
Applying NETLINK_AUDIT mask on architecture: x86
Failed to add audit seccomp rule, ignoring: Invalid argument
Applying NETLINK_AUDIT mask on architecture: x32
Applying NETLINK_AUDIT mask on architecture: x86-64
Inner child completed, invoking payload.
bash-5.2# 
```

</details>